### PR TITLE
Remove duplicate hero heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,6 @@
 
       <h1>Scalable AV &amp; Production Labor</h1>
 
-      <h1>Scalable AV &amp; Production Labor—On Time, On Budget</h1>
-
       <p>Nationwide staffing for corporate events, broadcast, and live productions.</p>
       <button class="btn-primary" onclick="location.href='#contact'">Request a Quote</button>
     </div>


### PR DESCRIPTION
## Summary
- Remove duplicate hero headline from the landing page's hero section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689287a158548331934acf884db4235c