### PR TITLE
Add white glow to Show Calling description

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     .card .card-overlay { position:absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; pointer-events:none; z-index:0; }
     .card > *:not(.card-overlay) { position:relative; z-index:1; }
     .card h3 { margin:1rem 0; font-family: var(--font-heading); }
+    .glow-text { text-shadow: 0 0 5px rgba(255, 255, 255, 0.8); }
     .clients-carousel { display:flex; overflow-x:auto; gap:2rem; padding:2rem 0; }
     .clients-carousel img { max-height:60px; filter:grayscale(100%); transition: filter 0.3s; }
     .clients-carousel img:hover { filter:grayscale(0%); }
@@ -88,7 +89,7 @@
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
         <h3>Show Calling</h3>
-        <p>Expert cue management for seamless event flow.</p>
+          <p class="glow-text">Expert cue management for seamless event flow.</p>
         <a href="#services">Learn More</a>
       </div>
       <div class="card">


### PR DESCRIPTION
## Summary
- add `.glow-text` CSS class providing a subtle white text-shadow
- apply `glow-text` to the Show Calling description for better visibility

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -q -e index.html` *(command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68929a1808b48331bdeee312332593ef