### PR TITLE
Make show calling text white

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
         <h3>Show Calling</h3>
-          <p class="glow-text">Expert cue management for seamless event flow.</p>
+          <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
         <a href="#services">Learn More</a>
       </div>
       <div class="card">


### PR DESCRIPTION
## Summary
- make Show Calling description text white for better contrast

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929bf4c7388331a57c984466384d40