### PR TITLE
Make 'Show Calling' heading white

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       <div class="card">
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
-        <h3>Show Calling</h3>
+        <h3 style="color: #fff;">Show Calling</h3>
           <p class="glow-text">Expert cue management for seamless event flow.</p>
         <a href="#services">Learn More</a>
       </div>


### PR DESCRIPTION
## Summary
- ensure 'Show Calling' service title displays in white for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929c9a242c8331842b83838d19295a