### PR TITLE
Add yellow overlay to highlight service link

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
     .hero-content h1 { font-family: var(--font-heading); font-size:3rem; margin-bottom:1rem; }
     .hero-content p { font-size:1.2rem; opacity:0.8; margin-bottom:2rem; }
     .btn-primary { background: var(--accent-color); color:#fff; padding:0.75rem 2rem; font-weight:600; border:none; cursor:pointer; }
+    .btn-overlay { position:relative; display:inline-block; padding:0.25rem 0.5rem; font-weight:600; color: var(--primary-color); }
+    .btn-overlay::before { content:""; position:absolute; inset:0; background:#ffff00; z-index:-1; border-radius:4px; }
     .services-cards { display:grid; grid-template-columns:repeat(auto-fit, minmax(250px,1fr)); gap:2rem; margin-top:2rem; }
     .card { position:relative; background:#f9f9f9; padding:1.5rem; border-radius:8px; text-align:center; overflow:hidden; }
     .card .card-overlay { position:absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; pointer-events:none; z-index:0; }
@@ -90,7 +92,7 @@
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
         <h3>Show Calling</h3>
           <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
-        <a href="#services">Learn More</a>
+        <a href="#services" class="btn-overlay">Learn More</a>
       </div>
       <div class="card">
         <img src="icon-audio.svg" alt="Audio Engineering Icon">


### PR DESCRIPTION
## Summary
- style overlay class that draws a yellow background behind text
- apply overlay to first "Learn More" link in services section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929d9db11083319e6eb54af20f3b11