### PR TITLE
fix: set Show Calling heading text to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,8 @@
       <div class="card">
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
-        <h3>Show Calling</h3>
-          <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
+        <h3 style="color: #fff;">Show Calling</h3>
+          <p class="glow-text">Expert cue management for seamless event flow.</p>
         <a href="#services">Learn More</a>
       </div>
       <div class="card">


### PR DESCRIPTION
## Summary
- make Show Calling card title white for readability

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929e40583c8331b537bc3bc8387db3