### PR TITLE
style: set Show Calling text to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
       <div class="card">
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
         <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
-        <h3>Show Calling</h3>
+        <h3 style="color: #fff;">Show Calling</h3>
           <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
         <a href="#services" class="btn-overlay">Learn More</a>
       </div>


### PR DESCRIPTION
## Summary
- ensure "Show Calling" header displays in white for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a07f8bec8331a7a6db8b16da126b