### PR TITLE
Replace show calling icon with glow effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     .card > *:not(.card-overlay) { position:relative; z-index:1; }
     .card h3 { margin:1rem 0; font-family: var(--font-heading); }
     .glow-text { text-shadow: 0 0 5px rgba(255, 255, 255, 0.8); }
+    .glow-icon { filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.8)); }
     .clients-carousel { display:flex; overflow-x:auto; gap:2rem; padding:2rem 0; }
     .clients-carousel img { max-height:60px; filter:grayscale(100%); transition: filter 0.3s; }
     .clients-carousel img:hover { filter:grayscale(0%); }
@@ -89,7 +90,7 @@
       <div class="services-cards">
       <div class="card">
         <img class="card-overlay" src="https://imgur.com/qqwyhuV.png" alt="">
-        <img src="https://imgur.com/I8xrZ60.png" alt="Show Calling Icon" width="80" height="80">
+        <img class="glow-icon" src="https://imgur.com/hA0Ghts.png" alt="Show Calling Icon" width="80" height="80">
         <h3 style="color: #fff;">Show Calling</h3>
           <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
         <a href="#services" class="btn-overlay">Learn More</a>


### PR DESCRIPTION
## Summary
- swap show calling card icon to new imgur source
- add CSS filter for subtle white drop-shadow behind the icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a9481a648331a25ba194220f6bec