### PR TITLE
Add yellow overlay to Audio Engineering Learn More button

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
         <img src="icon-audio.svg" alt="Audio Engineering Icon">
         <h3 class="glow-text" style="color: #fff;">Audio Engineering</h3>
         <p class="glow-text" style="color: #fff;">Professional FOH and Monitoring Engineering.</p>
-        <a href="#services">Learn More</a>
+        <a href="#services" class="btn-overlay">Learn More</a>
       </div>
       <div class="card">
         <img src="icon-video.svg" alt="Video Streaming Icon">


### PR DESCRIPTION
## Summary
- Add yellow overlay style to Audio Engineering 'Learn More' link for consistent styling.

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6892ad0286c883319ff31e32e18ea252