### PR TITLE
fix: close styled audio card

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,14 +97,12 @@
       </div>
       <div class="card" style="background:url('https://imgur.com/eMu9KVJ.png') center/cover no-repeat; height:220px;">
         <img class="glow-icon" src="https://imgur.com/yAJ58Sc.png" alt="Audio Engineering Icon" width="80" height="80">
-      <div class="card">
-        <img src="icon-audio.svg" alt="Audio Engineering Icon">
         <h3 class="glow-text" style="color: #fff;">Audio Engineering</h3>
         <p class="glow-text" style="color: #fff;">Professional FOH and Monitoring Engineering.</p>
         <a href="#services" class="btn-overlay">Learn More</a>
       </div>
       <div class="card">
-        <img src="icon-video.svg" alt="Video Streaming Icon">
+        <img src="icon-video.svg" alt="Video Streaming Icon" width="80" height="80">
         <h3>Video &amp; Streaming</h3>
         <p>High-definition video and live stream support.</p>
         <a href="#services">Learn More</a>


### PR DESCRIPTION
## Summary
- properly close Audio Engineering service card before starting next card
- ensure Video & Streaming card remains separate with consistent icon sizing

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892c73d4de48331852a27a4b36374cd