### PR TITLE
Add overlay image to video streaming card

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
         <a href="#services" class="btn-overlay">Learn More</a>
       </div>
       <div class="card" style="height:220px;">
+        <img class="card-overlay" src="https://imgur.com/a72fD2U.png" alt="" style="height:220px; width:100%; object-fit:cover;">
         <img src="icon-video.svg" alt="Video Streaming Icon" width="80" height="80">
         <h3>Video &amp; Streaming</h3>
         <p>High-definition video and live stream support.</p>


### PR DESCRIPTION
## Summary
- Add background image overlay for Video & Streaming service card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893d599267c833187701dc24e289858