### PR TITLE
Add Smart Source logo to clients carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     .glow-text { text-shadow: 0 0 5px rgba(255, 255, 255, 0.8); }
     .glow-icon { filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.8)); }
     .clients-carousel { display:flex; overflow-x:auto; gap:2rem; padding:2rem 0; }
-    .clients-carousel img { max-height:60px; filter:grayscale(100%); transition: filter 0.3s; }
+    .clients-carousel img { max-height:80px; filter:grayscale(100%); transition: filter 0.3s; }
     .clients-carousel img:hover { filter:grayscale(0%); }
     .three-cols { display:grid; grid-template-columns:repeat(3,1fr); gap:2rem; }
     .three-cols .col { text-align:center; }
@@ -115,6 +115,13 @@
   <section>
     <h2>Trusted By</h2>
     <div class="clients-carousel">
+      <img
+        src="https://thesmartsource.com/wp-content/uploads/2023/05/smart-source-logo.png"
+        alt="The Smart Source Logo"
+        width="80"
+        height="80"
+        style="object-fit: contain;"
+      >
       <img src="https://imgur.com/rNRtMwl.png" alt="Client Logo">
       <img src="https://imgur.com/Z0ry5Qc.png" alt="Client Logo">
       <img src="https://imgur.com/3RhWw3v.png" alt="Client Logo">


### PR DESCRIPTION
## Summary
- feature: include Smart Source logo in client carousel
- style: allow larger logo display by raising carousel image max height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ebeae9c083319eb65275d09a759a