### PR TITLE
feat: redirect careers form to Google Form prefill

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,17 +156,23 @@
   <section id="careers">
     <h2>Join Our Crew</h2>
     <p>We’re always looking for top-tier AV talent.</p>
-    <iframe name="hidden_iframe" style="display:none"></iframe>
-    <form id="careers-form" action="https://docs.google.com/forms/d/e/14379m2s5O2ER8_JIk_i__Lld8WBj6QqcX-eE80SnzUQ/formResponse" method="POST" target="hidden_iframe">
-      <input type="text" name="entry.1111111" placeholder="Full Name" required>
-      <input type="email" name="entry.2222222" placeholder="Email Address" required>
-      <input type="text" name="entry.3333333" placeholder="Position Interested" required>
-      <textarea name="entry.4444444" placeholder="Your Experience" rows="4"></textarea>
+    <form id="careers-form">
+      <input type="text" id="fullName" placeholder="Full Name" required>
+      <input type="email" id="emailAddress" placeholder="Email Address" required>
+      <input type="text" id="positionInterested" placeholder="Position Interested" required>
+      <textarea id="userExperience" placeholder="Your Experience" rows="4"></textarea>
       <button type="submit">Submit</button>
     </form>
     <script>
-      document.getElementById('careers-form').addEventListener('submit', function () {
-        alert('Thanks!');
+      document.getElementById('careers-form').addEventListener('submit', function (event) {
+        event.preventDefault();
+        const fullName = encodeURIComponent(document.getElementById('fullName').value);
+        const emailAddress = encodeURIComponent(document.getElementById('emailAddress').value);
+        const positionInterested = encodeURIComponent(document.getElementById('positionInterested').value);
+        const userExperience = encodeURIComponent(document.getElementById('userExperience').value);
+        const baseUrl = 'https://docs.google.com/forms/d/e/14379m2s5O2ER8_JIk_i__Lld8WBj6QqcX-eE80SnzUQ/viewform';
+        const query = `?entry.1111111=${fullName}&entry.2222222=${emailAddress}&entry.3333333=${positionInterested}&entry.4444444=${userExperience}`;
+        window.location.href = baseUrl + query;
       });
     </script>
   </section>


### PR DESCRIPTION
## Summary
- redirect Join Our Crew submissions to Google Form prefill via client-side redirect
- collect fields and build query string instead of posting directly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f5c6df148331add8deeef38af4ed