### PR TITLE
Enable Google Form iframe submission for Join Our Crew form

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,26 +156,25 @@
   <section id="careers">
     <h2>Join Our Crew</h2>
     <p>We’re always looking for top-tier AV talent.</p>
-    <form id="joinCrewForm">
+    <form id="joinCrewForm" action="https://docs.google.com/forms/d/e/1FAIpQLSdgqxCoVbSnsVnLkvFDJxypx4qPWJk6Ob-Z9fq1j0s_AmSR4A/formResponse" method="POST" target="gform_iframe">
       <input type="text" name="entry.1111111" placeholder="Full Name" required>
       <input type="email" name="entry.2222222" placeholder="Email Address" required>
       <input type="text" name="entry.3333333" placeholder="Position Interested" required>
       <textarea name="entry.4444444" placeholder="Your Experience"></textarea>
-      <button type="submit">Submit</button>
+      <button id="joinSubmit" type="submit">Submit</button>
     </form>
+    <iframe name="gform_iframe" id="gform_iframe" style="display:none;"></iframe>
+    <p id="joinMsg"></p>
     <script>
-      document.getElementById('joinCrewForm').addEventListener('submit', function(e) {
-        e.preventDefault();
-        const fullName = encodeURIComponent(document.querySelector('input[name="entry.1111111"]').value);
-        const email = encodeURIComponent(document.querySelector('input[name="entry.2222222"]').value);
-        const position = encodeURIComponent(document.querySelector('input[name="entry.3333333"]').value);
-        const experience = encodeURIComponent(document.querySelector('textarea[name="entry.4444444"]').value);
-        const url = 'https://docs.google.com/forms/d/e/1FAIpQLSdgqxCoVbSnsVnLkvFDJxypx4qPWJk6Ob-Z9fq1j0s_AmSR4A/viewform'
-          + '?entry.1111111=' + fullName
-          + '&entry.2222222=' + email
-          + '&entry.3333333=' + position
-          + '&entry.4444444=' + experience;
-        location.href = url;
+      const joinForm = document.getElementById('joinCrewForm');
+      const joinButton = document.getElementById('joinSubmit');
+      const joinMsg = document.getElementById('joinMsg');
+      const gformFrame = document.getElementById('gform_iframe');
+      joinForm.addEventListener('submit', function() {
+        joinButton.disabled = true;
+      });
+      gformFrame.addEventListener('load', function() {
+        joinMsg.textContent = 'Thanks!';
       });
     </script>
   </section>


### PR DESCRIPTION
## Summary
- Replace Join Our Crew form with a version that posts to Google Forms in a hidden iframe
- Disable submit button and display thanks message upon iframe load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950c47ff58833190906af070809cd5