### PR TITLE
Link service cards to pre-filled email inquiries

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,20 +92,29 @@
         <img class="glow-icon" src="https://imgur.com/hA0Ghts.png" alt="Show Calling Icon" width="80" height="80">
         <h3 style="color: #fff;">Show Calling</h3>
           <p class="glow-text" style="color: #fff;">Expert cue management for seamless event flow.</p>
-          <a href="#services" class="btn-overlay">Learn More</a>
+          <a
+            href="mailto:sheeksolutions@gmail.com?subject=Learn%20More%3A%20Show%20Calling&body=Hi%20Sheek%20Solutions%2C%0A%0AI%E2%80%99m%20interested%20in%20Show%20Calling%20services.%20Please%20share%20details%20and%20availability.%0A%0AEvent%20date%3A%20%0ALocation%3A%20%0ABudget%3A%20%0A%0AThanks%2C%0A[Your%20Name]"
+            class="btn-overlay"
+          >Learn More</a>
       </div>
       <div class="card" style="background:url('https://imgur.com/eMu9KVJ.png') center/cover no-repeat; height:220px;">
         <img class="glow-icon" src="https://imgur.com/yAJ58Sc.png" alt="Audio Engineering Icon" width="80" height="80">
         <h3 class="glow-text" style="color: #fff;">Audio Engineering</h3>
         <p class="glow-text" style="color: #fff;">Professional FOH and Monitoring Engineering.</p>
-        <a href="#services" class="btn-overlay">Learn More</a>
+        <a
+          href="mailto:sheeksolutions@gmail.com?subject=Learn%20More%3A%20Audio%20Engineering&body=Hi%20Sheek%20Solutions%2C%0A%0AI%E2%80%99m%20interested%20in%20Audio%20Engineering%20services.%20Please%20share%20details%20and%20availability.%0A%0AEvent%20date%3A%20%0ALocation%3A%20%0ABudget%3A%20%0A%0AThanks%2C%0A[Your%20Name]"
+          class="btn-overlay"
+        >Learn More</a>
       </div>
       <div class="card" style="height:220px;">
         <img class="card-overlay" src="https://imgur.com/a72fD2U.png" alt="" style="height:220px; width:100%; object-fit:cover;">
         <img src="https://imgur.com/uWosRFh.png" alt="Video Streaming Icon" width="80" height="80">
         <h3 class="glow-text" style="color: #fff;">Video &amp; Streaming</h3>
         <p class="glow-text" style="color: #fff;">High-definition video and live stream support.</p>
-          <a href="#services" class="btn-overlay">Learn More</a>
+          <a
+            href="mailto:sheeksolutions@gmail.com?subject=Learn%20More%3A%20Video%20%26%20Streaming&body=Hi%20Sheek%20Solutions%2C%0A%0AI%E2%80%99m%20interested%20in%20Video%20%26%20Streaming%20services.%20Please%20share%20details%20and%20availability.%0A%0AEvent%20date%3A%20%0ALocation%3A%20%0ABudget%3A%20%0A%0AThanks%2C%0A[Your%20Name]"
+            class="btn-overlay"
+          >Learn More</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- replace Services section 'Learn More' anchors with mailto links for Show Calling, Audio Engineering, and Video & Streaming

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952eab555c8331b3683b782694f2dc