### PR TITLE
Add mobile-specific hero titles

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,6 +25,14 @@
     .hero-content { position:relative; text-align:center; color: var(--primary-color); }
     .hero-content h1 { font-family: var(--font-heading); font-size:2.5rem; margin-bottom:1rem; }
     .hero-content p { font-size:1.2rem; opacity:0.8; }
+    .hero-title-mobile{
+      display:none;
+      font-family: var(--font-heading);
+      font-size: 2.5rem;
+      margin: 0 0 1rem;
+      color: var(--primary-color);
+      text-align: center;
+    }
     .btn-primary { background: var(--accent-color); color:#fff; padding:0.75rem 2rem; font-weight:600; border:none; cursor:pointer; }
     footer { background:#003366; color:#fff; text-align:center; padding:2rem 1rem; }
     .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:1000}
@@ -45,6 +53,11 @@
       .hero { height: 46vh; }
       .hero-content h1 { font-size: 2rem; }
       .hero-content p { font-size: 1rem; }
+    }
+
+    @media (max-width: 768px){
+      .hero-title-desktop{ display:none; }
+      .hero-title-mobile{ display:block; }
     }
 
     /* Mobile nav */
@@ -138,7 +151,8 @@
 
   <section class="hero">
     <div class="hero-content">
-      <h1>About Sheek Solutions</h1>
+      <h1 class="hero-title-desktop">About Sheek Solutions</h1>
+      <h1 class="hero-title-mobile">About Sheek Solutions</h1>
       <p>Nationwide AV professionals powering corporate events, broadcasts, and live productions.</p>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,14 @@
     .hero-content { position:relative; text-align:center; color: var(--primary-color); }
     .hero-content h1 { font-family: var(--font-heading); font-size:3rem; margin-bottom:1rem; }
     .hero-content p { font-size:1.2rem; opacity:0.8; margin-bottom:2rem; }
+    .hero-title-mobile{
+      display:none;
+      font-family: var(--font-heading);
+      font-size: 3rem;
+      margin: 0 0 1rem;
+      color: var(--primary-color);
+      text-align: center;
+    }
     .btn-primary { background: var(--accent-color); color:#fff; padding:0.75rem 2rem; font-weight:600; border:none; cursor:pointer; }
     .btn-overlay { position:relative; display:inline-block; padding:0.25rem 0.5rem; font-weight:600; color: var(--primary-color); }
     .btn-overlay::before { content:""; position:absolute; inset:0; background:#ffff00; z-index:-1; border-radius:4px; }
@@ -77,6 +85,11 @@
       }
       .hero-content h1{ font-size: 2rem; line-height: 1.2; }
       .hero-content p { font-size: 1rem; }
+    }
+
+    @media (max-width: 768px){
+      .hero-title-desktop{ display:none; }
+      .hero-title-mobile{ display:block; }
     }
 
     /* Mobile nav */
@@ -172,9 +185,8 @@
   <!-- Hero Section -->
   <section id="home" class="hero">
     <div class="hero-content">
-
-      <h1>Scalable AV &amp; Production Professionals</h1>
-
+      <h1 class="hero-title-desktop">Scalable AV &amp; Production Professionals</h1>
+      <h1 class="hero-title-mobile">Scalable AV &amp; Production Professionals</h1>
       <p>Nationwide staffing for corporate events, broadcast, and live productions.</p>
       <button class="btn-primary" onclick="window.location.href='mailto:sheeksolutions@gmail.com?subject=Quote%20Request';">Request a Quote</button>
     </div>


### PR DESCRIPTION
## Summary
- Hide desktop hero title on small screens and display a mobile-positioned title on the home page
- Apply the same mobile title swap to the about page for consistent behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689661c96130833189dd4ef62a611a35