### PR TITLE
feat: add hero load-in animation

### DIFF
--- a/about.html
+++ b/about.html
@@ -68,6 +68,26 @@
       .nav-logo img{ max-height: 38px !important; }
       */
     }
+
+    /* Hero load-in animation */
+    .hero{
+      opacity: 0;
+      transform: translateY(20px);
+      animation: fadeSlideUp 1.5s ease forwards;
+      will-change: transform, opacity;
+    }
+
+    @keyframes fadeSlideUp{
+      to{
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    /* Respect users who prefer reduced motion */
+    @media (prefers-reduced-motion: reduce){
+      .hero{ animation: none; opacity: 1; transform: none; }
+    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -88,6 +88,26 @@
       .nav-logo img{ max-height: 38px !important; }
       */
     }
+
+    /* Hero load-in animation */
+    .hero{
+      opacity: 0;
+      transform: translateY(20px);
+      animation: fadeSlideUp 1.5s ease forwards;
+      will-change: transform, opacity;
+    }
+
+    @keyframes fadeSlideUp{
+      to{
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    /* Respect users who prefer reduced motion */
+    @media (prefers-reduced-motion: reduce){
+      .hero{ animation: none; opacity: 1; transform: none; }
+    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/mobile.css
+++ b/mobile.css
@@ -67,3 +67,23 @@ img, video { max-width: 100%; height: auto; }
   .btn-primary, .btn, .btn-overlay{ padding: .9rem 1.1rem; font-size: 1rem; }
   input, textarea, select{ font-size: 16px; } /* prevent iOS zoom on focus */
 }
+
+/* Hero load-in animation */
+.hero{
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeSlideUp 1.5s ease forwards;
+  will-change: transform, opacity;
+}
+
+@keyframes fadeSlideUp{
+  to{
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .hero{ animation: none; opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## Summary
- add fade-in slide-up animation for hero sections
- respect users' reduced-motion preferences

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966a8050b083318d2c7d5045a55da0