### PR TITLE
Increase hero animation duration to 2.5s

### DIFF
--- a/about.html
+++ b/about.html
@@ -73,7 +73,7 @@
     .hero{
       opacity: 0;
       transform: translateY(20px);
-      animation: fadeSlideUp 1.5s ease forwards;
+      animation: fadeSlideUp 2.5s ease forwards;
       will-change: transform, opacity;
     }
 

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
     .hero{
       opacity: 0;
       transform: translateY(20px);
-      animation: fadeSlideUp 1.5s ease forwards;
+      animation: fadeSlideUp 2.5s ease forwards;
       will-change: transform, opacity;
     }
 

--- a/mobile.css
+++ b/mobile.css
@@ -72,7 +72,7 @@ img, video { max-width: 100%; height: auto; }
 .hero{
   opacity: 0;
   transform: translateY(20px);
-  animation: fadeSlideUp 1.5s ease forwards;
+  animation: fadeSlideUp 2.5s ease forwards;
   will-change: transform, opacity;
 }
 


### PR DESCRIPTION
## Summary
- extend hero animation duration to 2.5 seconds across about page, mobile stylesheet, and homepage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966ce06dc083319840b10a671c463f