### PR TITLE
Tune mobile hero heading size

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -49,10 +49,10 @@ img, video { max-width: 100%; height: auto; }
 
   /* swap titles: hide desktop h1 over the logo, show mobile h1 above tagline */
   .hero-content h1.hero-title-desktop{ display: none; }
-  .hero-title-mobile{ display: block; }
+  .hero-title-mobile{ display: block; font-size: 1.6rem; }
 
   /* type sizes */
-  .hero-content h1{ font-size: 2rem; line-height: 1.2; }
+  .hero-content h1{ font-size: 1.6rem; line-height: 1.2; }
   .hero-content p { font-size: 1rem; }
 
   /* cards/grid */


### PR DESCRIPTION
## Summary
- Decrease mobile hero heading and mobile-only title to 1.6rem for better readability on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966e5aa7c0833197e5f605997a19da