### PR TITLE
feat: adjust hero background size on desktop

### DIFF
--- a/about.html
+++ b/about.html
@@ -87,6 +87,14 @@
         transform: none !important;    /* kill any earlier scale() */
       }
     }
+
+    /* Desktop-only hero background tweak */
+    @media (min-width: 1024px){
+      .hero{
+        background-size: 95% auto !important; /* 5% smaller than current */
+        background-position: top center;      /* keep it centered at the top */
+      }
+    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -107,6 +107,14 @@
         transform: none !important;    /* kill any earlier scale() */
       }
     }
+
+    /* Desktop-only hero background tweak */
+    @media (min-width: 1024px){
+      .hero{
+        background-size: 95% auto !important; /* 5% smaller than current */
+        background-position: top center;      /* keep it centered at the top */
+      }
+    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/mobile.css
+++ b/mobile.css
@@ -87,3 +87,11 @@ img, video { max-width: 100%; height: auto; }
 @media (prefers-reduced-motion: reduce){
   .hero{ animation: none; opacity: 1; transform: none; }
 }
+
+/* Desktop-only hero background tweak */
+@media (min-width: 1024px){
+  .hero{
+    background-size: 95% auto !important; /* 5% smaller than current */
+    background-position: top center;      /* keep it centered at the top */
+  }
+}


### PR DESCRIPTION
## Summary
- Ensure hero background logo appears 5% smaller on desktop layouts
- Keep background centered at the top for desktop viewports

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689674a42c648331ac9b38087b0d7e21