### PR TITLE
Use img for hero art instead of background

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,7 +21,7 @@
     nav ul li a { font-weight:600; color: var(--primary-color); }
     nav ul li a:hover { color: var(--accent-color); }
     section { padding:4rem 1rem; max-width:1200px; margin:0 auto; }
-    .hero { position:relative; background:url('https://imgur.com/1qSwsv5.png') center/cover no-repeat; height:40vh; display:flex; align-items:center; justify-content:center; }
+    .hero { position:relative; height:40vh; display:flex; align-items:center; justify-content:center; }
     .hero-content { position:relative; text-align:center; color: var(--primary-color); }
     .hero-content h1 { font-family: var(--font-heading); font-size:2.5rem; margin-bottom:1rem; }
     .hero-content p { font-size:1.2rem; opacity:0.8; }
@@ -88,13 +88,6 @@
       }
     }
 
-    /* Desktop-only hero background tweak */
-    @media (min-width: 1024px){
-      .hero{
-        background-size: 95% auto !important; /* 5% smaller than current */
-        background-position: top center;      /* keep it centered at the top */
-      }
-    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>
@@ -120,6 +113,7 @@
 
   <section class="hero">
     <div class="hero-content">
+      <img class="hero-art" src="https://imgur.com/1qSwsv5.png" alt="Sheek Solutions logo">
       <h1 class="hero-title-desktop">About Sheek Solutions</h1>
       <h1 class="hero-title-mobile">About Sheek Solutions</h1>
       <p>Nationwide AV professionals powering corporate events, broadcasts, and live productions.</p>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     nav ul li a { font-weight:600; color: var(--primary-color); }
     nav ul li a:hover { color: var(--accent-color); }
     section { padding:4rem 1rem; max-width:1200px; margin:0 auto; }
-    .hero { position:relative; background:url('https://imgur.com/1qSwsv5.png') center/cover no-repeat; height:70vh; display:flex; align-items:center; justify-content:center; }
+    .hero { position:relative; height:70vh; display:flex; align-items:center; justify-content:center; }
     .hero::after { content:""; position:absolute; inset:0; background: transparent; }
     .hero-content { position:relative; text-align:center; color: var(--primary-color); }
     .hero-content h1 { font-family: var(--font-heading); font-size:3rem; margin-bottom:1rem; }
@@ -108,13 +108,6 @@
       }
     }
 
-    /* Desktop-only hero background tweak */
-    @media (min-width: 1024px){
-      .hero{
-        background-size: 95% auto !important; /* 5% smaller than current */
-        background-position: top center;      /* keep it centered at the top */
-      }
-    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>
@@ -142,6 +135,7 @@
   <!-- Hero Section -->
   <section id="home" class="hero">
     <div class="hero-content">
+      <img class="hero-art" src="https://imgur.com/1qSwsv5.png" alt="Sheek Solutions logo">
       <h1 class="hero-title-desktop">Scalable AV &amp; Production Professionals</h1>
       <h1 class="hero-title-mobile">Scalable AV &amp; Production Professionals</h1>
       <p>Nationwide staffing for corporate events, broadcast, and live productions.</p>

--- a/mobile.css
+++ b/mobile.css
@@ -1,6 +1,13 @@
 /* Global safe helper */
 img, video { max-width: 100%; height: auto; }
 
+.hero-art{
+  width: min(900px, 80vw);
+  height: auto;
+  display: block;
+  margin: 0 auto 1rem;
+}
+
 /* Mobile-only alternate hero title (hidden by default; shown at <=768px) */
 .hero-title-mobile{
   display: none;
@@ -38,14 +45,13 @@ img, video { max-width: 100%; height: auto; }
   /* spacing */
   section{ padding: 2.5rem 1rem; }
 
-  /* shrink the cloud logo background & improve contrast */
+  /* mobile hero adjustments */
   .hero{
-    background-position: top center !important;
-    background-size: 60% auto !important;
     height: 48vh;
     padding-top: 1.25rem;
   }
   .hero::after{ background: rgba(255,255,255,0.20) !important; }
+  .hero-art{ width: 60vw; }
 
   /* swap titles: hide desktop h1 over the logo, show mobile h1 above tagline */
   .hero-content h1.hero-title-desktop{ display: none; }
@@ -88,10 +94,3 @@ img, video { max-width: 100%; height: auto; }
   .hero{ animation: none; opacity: 1; transform: none; }
 }
 
-/* Desktop-only hero background tweak */
-@media (min-width: 1024px){
-  .hero{
-    background-size: 95% auto !important; /* 5% smaller than current */
-    background-position: top center;      /* keep it centered at the top */
-  }
-}


### PR DESCRIPTION
## Summary
- Replace CSS background hero image with an inline `<img>` on home and about pages for natural scaling
- Add responsive styling for the new hero art and remove obsolete background rules

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689676f55b1c833189a1cc17275b8fdb