### PR TITLE
Consolidate hero and nav styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,33 +77,6 @@
       .hero{ animation: none; opacity: 1; transform: none; }
     }
 
-    /* Desktop-only hero background tweak */
-    @media (min-width: 1024px){
-      .hero{
-        background-size: 95% auto !important; /* 5% smaller than current */
-        background-position: top center;      /* keep it centered at the top */
-      }
-    }
-    /* base */
-    .nav-logo .logo-img{ width:auto; object-fit:contain; display:block; }
-
-    /* MOBILE: +10% (28px -> ~31px) */
-    @media (max-width:900px){
-      .nav-logo .logo-img{ max-height:31px !important; }
-    }
-
-    /* DESKTOP: +5% (40px -> 42px) */
-    @media (min-width:1024px){
-      .nav-logo .logo-img{
-        max-height:42px !important;
-        transform:none !important; /* cancel any previous scale() rules */
-      }
-    }
-
-    /* Optional: slightly increase header padding on desktop */
-    @media (min-width:1024px){
-      .nav-container{ padding-block:0.9rem; }
-    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -97,33 +97,6 @@
       .hero{ animation: none; opacity: 1; transform: none; }
     }
 
-    /* Desktop-only hero background tweak */
-    @media (min-width: 1024px){
-      .hero{
-        background-size: 95% auto !important; /* 5% smaller than current */
-        background-position: top center;      /* keep it centered at the top */
-      }
-    }
-    /* base */
-    .nav-logo .logo-img{ width:auto; object-fit:contain; display:block; }
-
-    /* MOBILE: +10% (28px -> ~31px) */
-    @media (max-width:900px){
-      .nav-logo .logo-img{ max-height:31px !important; }
-    }
-
-    /* DESKTOP: +5% (40px -> 42px) */
-    @media (min-width:1024px){
-      .nav-logo .logo-img{
-        max-height:42px !important;
-        transform:none !important; /* cancel any previous scale() rules */
-      }
-    }
-
-    /* Optional: slightly increase header padding on desktop */
-    @media (min-width:1024px){
-      .nav-container{ padding-block:0.9rem; }
-    }
   </style>
   <link rel="stylesheet" href="mobile.css">
   </head>

--- a/mobile.css
+++ b/mobile.css
@@ -1,6 +1,13 @@
 /* Global safe helper */
 img, video { max-width: 100%; height: auto; }
 
+/* base */
+.nav-logo .logo-img{
+  width:auto;
+  object-fit:contain;
+  display:block;
+}
+
 /* Mobile-only alternate hero title (hidden by default; shown at <=768px) */
 .hero-title-mobile{
   display: none;
@@ -14,7 +21,7 @@ img, video { max-width: 100%; height: auto; }
 /* <=900px — mobile/tablet nav */
 @media (max-width: 900px){
   .nav-container{ flex-wrap: wrap; gap: .5rem; align-items: center; }
-  .nav-logo .logo-img{ max-height: 31px; }
+  .nav-logo .logo-img{ max-height: 31px !important; }
 
   .nav-toggle{
     display: inline-block;
@@ -88,10 +95,15 @@ img, video { max-width: 100%; height: auto; }
   .hero{ animation: none; opacity: 1; transform: none; }
 }
 
-/* Desktop-only hero background tweak */
+/* Desktop-only hero background tweak and header adjustments */
 @media (min-width: 1024px){
   .hero{
     background-size: 95% auto !important; /* 5% smaller than current */
     background-position: top center;      /* keep it centered at the top */
   }
+  .nav-logo .logo-img{
+    max-height:42px !important;
+    transform:none !important; /* cancel any previous scale() rules */
+  }
+  .nav-container{ padding-block:0.9rem; }
 }


### PR DESCRIPTION
## Summary
- centralize navigation logo sizing and desktop hero tweaks in `mobile.css`
- drop duplicate hero and nav CSS from `index.html` and `about.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689678aba0a88331b23e77c11c8b94b6