### PR TITLE
Add mobile-specific hero logo to prevent overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
   <!-- Hero Section -->
   <section id="home" class="hero">
     <div class="hero-content">
+      <img class="hero-art-mobile" src="https://imgur.com/1qSwsv5.png" alt="Sheek Solutions logo">
       <h1 class="hero-title-desktop">Scalable AV &amp; Production Professionals</h1>
       <h1 class="hero-title-mobile">Scalable AV &amp; Production Professionals</h1>
       <p>Nationwide staffing for corporate events, broadcast, and live productions.</p>

--- a/mobile.css
+++ b/mobile.css
@@ -18,6 +18,11 @@ img, video { max-width: 100%; height: auto; }
   text-align: center;
 }
 
+/* Mobile hero logo (hidden by default) */
+.hero-art-mobile{
+  display: none;
+}
+
 /* <=900px — mobile/tablet nav */
 @media (max-width: 900px){
   .nav-container{ flex-wrap: wrap; gap: .5rem; align-items: center; }
@@ -45,21 +50,28 @@ img, video { max-width: 100%; height: auto; }
   /* spacing */
   section{ padding: 2.5rem 1rem; }
 
-  /* shrink the cloud logo background & improve contrast */
-  .hero{
-    background-position: top center !important;
-    background-size: 60% auto !important;
-    height: 48vh;
-    padding-top: 1.25rem;
-  }
-  .hero::after{ background: rgba(255,255,255,0.20) !important; }
+  /* stop using the background so text can't overlap the wordmark */
+  .hero{ background: none !important; padding-top: 1rem; }
 
-  /* swap titles: hide desktop h1 over the logo, show mobile h1 above tagline */
-  .hero-content h1.hero-title-desktop{ display: none; }
-  .hero-title-mobile{ display: block; font-size: 1.6rem; margin-top: -50px; margin-bottom: 2em; /* extra space between title and tagline */ }
+  /* show the mobile-only logo image */
+  .hero-art-mobile{
+    display: block;
+    width: 68vw;
+    max-width: 420px;
+    height: auto;
+    margin: 0 auto 12px;
+  }
+
+  /* keep only the mobile title visible and keep it smaller */
+  .hero-title-desktop{ display: none; }
+  .hero-title-mobile{
+    display: block;
+    font-size: 1.5rem;
+    line-height: 1.15;
+    margin: 0 0 1.25rem;
+  }
 
   /* type sizes */
-  .hero-content h1{ font-size: 1.6rem; line-height: 1.2; }
   .hero-content p { font-size: 1rem; }
 
   /* cards/grid */


### PR DESCRIPTION
## Summary
- add a dedicated mobile logo image above hero title
- strip hero background and hide desktop title on small screens

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967c8be34c83319f41d66adcfe6d81